### PR TITLE
Add '-content' suffix to the main md file, and remove '.wrapper' from…

### DIFF
--- a/convert.js
+++ b/convert.js
@@ -42,7 +42,8 @@ function convert( sourceFilename, extension, doConversion )
 
 function markdownToLatex( filename )
 {
-    convert( filename, ".tex", function( lines )
+    const suffix = "-content";
+    convert( filename, suffix + ".tex", function( lines )
     {
         function indentation( adjustment )
         {
@@ -258,7 +259,7 @@ function markdownToLatex( filename )
         return newLines;
     } );
 
-    latexwrapper.createLatexWrapper( filename );
+    latexwrapper.createLatexWrapper( filename, suffix );
 };
 
 

--- a/latexwrapper.js
+++ b/latexwrapper.js
@@ -87,17 +87,17 @@ function writeLatexWrapper(filename, lines)
     fs.writeFileSync(filename, lines.join('\n')+'\n');
 }
 
-function createLatexWrapper( sourceFilename )
+function createLatexWrapper( sourceFilename, contentSuffix )
 {
     var lines = fs.readFileSync( sourceFilename ).toString().split( /\r?\n/ );
     var properties = parseProperties( lines );
 
     var sourceFilenameKey = "__md-source-filename";
-    properties[sourceFilenameKey] = properties[sourceFilenameKey] || [ path.basename(sourceFilename).replace(/ /g, '_') ];
+    properties[sourceFilenameKey] = properties[sourceFilenameKey] || [ path.basename(sourceFilename + contentSuffix).replace(/ /g, '_') ];
 
     wrapperLines = compileLatexWrapper(properties);
 
-    var wrapperFilename = sourceFilename + '.wrapper.tex';
+    var wrapperFilename = sourceFilename + '.tex';
 
     if( wrapperLines )
     {


### PR DESCRIPTION
… wrapper tex

This then gives the main .tex file the same name as the original .md file
without the '.wrapper' suffix.